### PR TITLE
yarn-deduplicate when renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "postUpdateOptions": ["yarnDedupeHighest"]
     }
   ]
 }


### PR DESCRIPTION
because: #113

- https://docs.renovatebot.com/configuration-options/#postupdateoptions
