### PR TITLE
group types react and react-dom

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "postUpdateOptions": ["yarnDedupeHighest"]
+    },
+    {
+      "packagePatterns": ["^@types/react(|-dom)$"],
+      "groupName": "@types/react, @types/react-dom"
     }
   ]
 }


### PR DESCRIPTION
because: #113 

- https://docs.renovatebot.com/configuration-options/#packagerules
- cf. #117 